### PR TITLE
Allow running with QEMU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ##Top level makefile for local installation of source tree
 SRC=herd gen litmus tools
-PREFIX=~/local
+PREFIX=$$HOME
 OCBOPT=
 default: all
 

--- a/diy/doc/litmus.tex
+++ b/diy/doc/litmus.tex
@@ -1429,7 +1429,7 @@ In the ``\opt{C}'' mode, one executable \file{run.exe} is produced, which
 will launch the tests (see Sec.~\ref{driverc:example} for an example).
 Finally, the \opt{XCode} mode is for inclusion of the tests into
 a dedicated iOS App, which we do not distribute at the moment.
-\item[{\tt -crossrun <(user@)?host(:port)?|adb>}]
+\item[{\tt -crossrun <(user@)?host(:port)?|adb|qemu>}]
 When the shell driver is used (\opt{-driver shell} above),
 \aname{crossrun}{instruct}
 the \texttt{run.sh} script to run individual tests on a remote machine.

--- a/litmus/crossrun.ml
+++ b/litmus/crossrun.ml
@@ -17,14 +17,16 @@ type addr ={ host : string ; port : int option ; }
 
 type t =
   | Host of addr
+  | Qemu
   | Adb
   | No
 
-let tags = ["none";"adb";"host[:port]";]
+let tags = ["none";"adb";"qemu";"host[:port]";]
 
 let parse tag = match tag with
 | "none" -> Some No
 | "adb"  -> Some Adb
+| "qemu"  -> Some Qemu
 | _ ->
     let h =
       try
@@ -42,6 +44,7 @@ open Printf
 let pp = function
   | No -> "none"
   | Adb -> "adb"
+  | Qemu -> "qemu"
   | Host h ->
       match h.port with
       | None -> h.host

--- a/litmus/crossrun.mli
+++ b/litmus/crossrun.mli
@@ -17,6 +17,7 @@ type addr ={ host : string ; port : int option ; }
 
 type t =
   | Host of addr
+  | Qemu
   | Adb
   | No
 

--- a/litmus/dumpRun.ml
+++ b/litmus/dumpRun.ml
@@ -206,6 +206,8 @@ let dump_shell names =
       output_line out_chan "LITMUSOPTS=\"${@:-$LITMUSOPTS}\"" ;
       begin match Cfg.crossrun with
       | Crossrun.No -> ()
+      | Crossrun.Qemu ->
+          fprintf out_chan "# Set $QEMU to run under QEMU\n";
       | Crossrun.Adb  ->
           fprintf out_chan "RDIR=%s\n" Cfg.adbdir ;
           fprintf out_chan "adb shell mkdir $RDIR >/dev/null 2>&1\n" ;

--- a/litmus/run.ml
+++ b/litmus/run.ml
@@ -113,6 +113,7 @@ module Make(O:Config)(Tar:Tar.S)(D:Test) =
           match O.crossrun with
           | Crossrun.No -> sprintf "%s %s" exe opts
           | Crossrun.Adb ->  sprintf "dorun %s %s" exe opts
+          | Crossrun.Qemu ->  sprintf "$QEMU %s %s" exe opts
           | Crossrun.Host _h ->
               let scp = sprintf "doscp %s" exe in
               let run = sprintf "%s %s" exe opts in


### PR DESCRIPTION
There are two fixes here. The first is a simple fix for installing in $HOME which got removed with a previous merge. After that an extension that allows crossrun = qemu to be specified for the run script.